### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
This adds support for dependabot dependency management. It will scan the repository daily for any available updates to existing dependencies. These will get raised as PRs

Closes #5 

https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates