### PR TITLE
Avoid running reduce on an empty collection

### DIFF
--- a/src/main/kotlin/com/wquasar/codeowners/lens/core/CodeOwnerService.kt
+++ b/src/main/kotlin/com/wquasar/codeowners/lens/core/CodeOwnerService.kt
@@ -65,11 +65,13 @@ internal class CodeOwnerService {
             .filterNotNull()
             .toCollection(LinkedHashSet())
             .also { rules ->
-                val commonPredicate = findCommonPredicate(rules)
-                commonCodeOwnerPrefix = commonPredicate
-                if (commonPredicate.isNotBlank()) {
-                    rules.forEach { rule ->
-                        rule.owners = rule.owners.map { it.removePrefix(commonPredicate) }
+                if (rules.isNotEmpty()) {
+                    val commonPredicate = findCommonPredicate(rules)
+                    commonCodeOwnerPrefix = commonPredicate
+                    if (commonPredicate.isNotBlank()) {
+                        rules.forEach { rule ->
+                            rule.owners = rule.owners.map { it.removePrefix(commonPredicate) }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #13 

Maybe not the most elegant way and not sure if this is how it should work, but at least shouldn't throw the exception anymore.