### PR TITLE
Update IntelliJ platform plugin version to 2.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ intellijPlatform {
     projectName = project.name
 
     group = "com.wquasar"
-    version = "0.6.9"
+    version = "0.6.10"
 
     pluginConfiguration {
         ideaVersion {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.1.21"
-intellij = "2.0.1"
+intellij = "2.6.0"
 sinceBuild = "231"
 intellijPlugin = "2024.1.5"
 dagger = "2.10"


### PR DESCRIPTION
The older IntelliJ Platform Plugin version 2.0.1 was defaulting the `until-build` property to `241.*`. Updated the plugin to version 2.6.0 to get rid of this hardcoded plugin property. Now the `until-build` version is unrestricted.

Properly addresses #28.